### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,4 +1,6 @@
 name: tfsec Terraform Security Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/KuduWorks/fictional-octo-system/security/code-scanning/1](https://github.com/KuduWorks/fictional-octo-system/security/code-scanning/1)

To remediate the issue, explicitly add a `permissions` key with the least privilege needed. In this case, the job checks out code and runs a scan, so only `contents: read` is required. The `permissions` block can be placed at the top level of the workflow (just below `name:` and above `on:`) to apply globally to all jobs, or, for finer granularity, at the job level. Since there is only one job and no indication more will be added, it is simplest to add it at the top level.  
**Edit:** Add the following to `.github/workflows/tfsec.yml` after the `name:` line:
```yaml
permissions:
  contents: read
```
No new imports or methods are needed, just this additional block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
