### PR TITLE
Remove APIM TLS policy and update App Service TLS policy definition

### DIFF
--- a/deployments/azure/policies/iso27001-crypto/main.tf
+++ b/deployments/azure/policies/iso27001-crypto/main.tf
@@ -706,6 +706,12 @@ resource "azurerm_subscription_policy_assignment" "function_app_tls_12" {
     control    = "A.10.1.1"
     assignedBy = "Terraform"
   })
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  location = "swedencentral"  # Required when identity is specified
 }
 
 # Service Bus CMK Policy


### PR DESCRIPTION
Eliminate the API Management TLS policy and adjust the App Service TLS policy definition to ensure compliance with ISO 27001 standards.