### PR TITLE
Fix typo in Terraform validation command

### DIFF
--- a/deployments/aws/QUICKSTART.md
+++ b/deployments/aws/QUICKSTART.md
@@ -44,6 +44,9 @@ cp terraform.tfvars.example terraform.tfvars
 # Initialize Terraform
 terraform init
 
+# Check that your code is structurally correct
+terrafrom validate
+
 # Preview what will be created
 terraform plan
 


### PR DESCRIPTION
Correct the typo in the command used to validate Terraform configuration.