### PR TITLE
Add RDS SSL/TLS parameter groups and update documentation for encryption enforcement

### DIFF
--- a/deployments/aws/management/policies/encryption-baseline/MULTI_VERSION_GUIDE.md
+++ b/deployments/aws/management/policies/encryption-baseline/MULTI_VERSION_GUIDE.md
@@ -1,0 +1,225 @@
+# Multi-Version RDS SSL/TLS Parameter Groups
+
+## ✅ Complete Solution
+
+Your encryption baseline now supports **ALL major RDS database versions** - no more version compatibility issues!
+
+## 📋 Available Parameter Groups
+
+### PostgreSQL (5 versions)
+| Version | Parameter Group Name | Family |
+|---------|---------------------|---------|
+| PostgreSQL 12 | `postgresql-postgres12-ssl-required` | postgres12 |
+| PostgreSQL 13 | `postgresql-postgres13-ssl-required` | postgres13 |
+| PostgreSQL 14 | `postgresql-postgres14-ssl-required` | postgres14 |
+| PostgreSQL 15 | `postgresql-postgres15-ssl-required` | postgres15 |
+| PostgreSQL 16 | `postgresql-postgres16-ssl-required` | postgres16 |
+
+**SSL Parameter**: `rds.force_ssl = 1`
+
+---
+
+### MySQL (2 versions)
+| Version | Parameter Group Name | Family |
+|---------|---------------------|---------|
+| MySQL 5.7 | `mysql-mysql57-ssl-required` | mysql5.7 |
+| MySQL 8.0 | `mysql-mysql80-ssl-required` | mysql8.0 |
+
+**SSL Parameter**: `require_secure_transport = ON`
+
+---
+
+### Aurora PostgreSQL (4 versions)
+| Version | Parameter Group Name | Family |
+|---------|---------------------|---------|
+| Aurora PostgreSQL 13 | `aurora-postgresql13-ssl-required` | aurora-postgresql13 |
+| Aurora PostgreSQL 14 | `aurora-postgresql14-ssl-required` | aurora-postgresql14 |
+| Aurora PostgreSQL 15 | `aurora-postgresql15-ssl-required` | aurora-postgresql15 |
+| Aurora PostgreSQL 16 | `aurora-postgresql16-ssl-required` | aurora-postgresql16 |
+
+**SSL Parameter**: `rds.force_ssl = 1`
+
+---
+
+### Aurora MySQL (2 versions)
+| Version | Parameter Group Name | Family |
+|---------|---------------------|---------|
+| Aurora MySQL 5.7 | `aurora-mysql5-7-ssl-required` | aurora-mysql5.7 |
+| Aurora MySQL 8.0 | `aurora-mysql8-0-ssl-required` | aurora-mysql8.0 |
+
+**SSL Parameter**: `require_secure_transport = ON`
+
+**Note**: Dots in version numbers are replaced with hyphens in parameter group names due to AWS naming restrictions.
+
+---
+
+## 🎯 How It Works
+
+### Using `for_each` for Multi-Version Support
+
+The Terraform configuration uses `for_each` loops to create parameter groups for all supported versions:
+
+```hcl
+locals {
+  postgresql_families = ["postgres12", "postgres13", "postgres14", "postgres15", "postgres16"]
+  mysql_families      = ["mysql5.7", "mysql8.0"]
+  aurora_pg_families  = ["aurora-postgresql13", "aurora-postgresql14", "aurora-postgresql15", "aurora-postgresql16"]
+  aurora_my_families  = ["aurora-mysql5.7", "aurora-mysql8.0"]
+}
+
+resource "aws_db_parameter_group" "postgresql_ssl_required" {
+  for_each = toset(local.postgresql_families)
+  
+  name   = "postgresql-${each.value}-ssl-required"
+  family = each.value
+  # ... SSL configuration
+}
+```
+
+This approach:
+- ✅ Creates parameter groups for all versions automatically
+- ✅ Makes it easy to add/remove versions by updating the locals
+- ✅ Ensures consistent SSL configuration across all versions
+- ✅ No need to manually manage each version
+
+---
+
+## 💡 Usage Examples
+
+### Match Your Database Version
+
+```hcl
+# PostgreSQL 15 instance
+resource "aws_db_instance" "app_db" {
+  engine              = "postgres"
+  engine_version      = "15.4"
+  parameter_group_name = "postgresql-postgres15-ssl-required"  # ✅ Version 15
+  storage_encrypted   = true
+}
+
+# MySQL 5.7 instance
+resource "aws_db_instance" "legacy_db" {
+  engine              = "mysql"
+  engine_version      = "5.7.44"
+  parameter_group_name = "mysql-mysql57-ssl-required"  # ✅ Version 5.7
+  storage_encrypted   = true
+}
+
+# Aurora PostgreSQL 16 cluster
+resource "aws_rds_cluster" "main_cluster" {
+  engine              = "aurora-postgresql"
+  engine_version      = "16.1"
+  db_cluster_parameter_group_name = "aurora-postgresql16-ssl-required"  # ✅ Version 16
+  storage_encrypted   = true
+}
+
+# Aurora MySQL 8.0 cluster
+resource "aws_rds_cluster" "analytics_cluster" {
+  engine              = "aurora-mysql"
+  engine_version      = "8.0.mysql_aurora.3.05.2"
+  db_cluster_parameter_group_name = "aurora-mysql8-0-ssl-required"  # ✅ Version 8.0
+  storage_encrypted   = true
+}
+```
+
+---
+
+## 🔍 Version Compatibility Checking
+
+The parameter group `family` must match your database engine version:
+
+| Engine Version | Compatible Family |
+|---------------|-------------------|
+| postgres 12.x | postgres12 |
+| postgres 13.x | postgres13 |
+| postgres 14.x | postgres14 |
+| postgres 15.x | postgres15 |
+| postgres 16.x | postgres16 |
+| mysql 5.7.x | mysql5.7 |
+| mysql 8.0.x | mysql8.0 |
+| aurora-postgresql 13.x | aurora-postgresql13 |
+| aurora-postgresql 14.x | aurora-postgresql14 |
+| aurora-postgresql 15.x | aurora-postgresql15 |
+| aurora-postgresql 16.x | aurora-postgresql16 |
+| aurora-mysql 5.7.x | aurora-mysql5.7 |
+| aurora-mysql 8.0.x | aurora-mysql8.0 |
+
+---
+
+## 🚀 Benefits of Multi-Version Support
+
+### Before (Single Version)
+```hcl
+# Only worked with Postgres 16
+resource "aws_db_parameter_group" "postgresql_ssl_required" {
+  name   = "postgresql-ssl-required"
+  family = "postgres16"  # ❌ Fixed to version 16
+}
+```
+
+**Problem**: If you had Postgres 15, 14, or 13 instances, you couldn't use this parameter group!
+
+### After (All Versions)
+```hcl
+# Works with ALL PostgreSQL versions
+resource "aws_db_parameter_group" "postgresql_ssl_required" {
+  for_each = toset(["postgres12", "postgres13", "postgres14", "postgres15", "postgres16"])
+  
+  name   = "postgresql-${each.value}-ssl-required"
+  family = each.value  # ✅ Creates one for each version
+}
+```
+
+**Solution**: Now you have a parameter group for every supported version!
+
+---
+
+## 📝 Adding New Versions
+
+When AWS releases new versions, simply update the locals:
+
+```hcl
+locals {
+  # Add postgres17 when available
+  postgresql_families = ["postgres12", "postgres13", "postgres14", "postgres15", "postgres16", "postgres17"]
+}
+```
+
+Then run `terraform apply` to create the new parameter groups.
+
+---
+
+## ✅ Verification
+
+List all parameter groups:
+
+```bash
+# PostgreSQL
+aws rds describe-db-parameter-groups \
+  --query "DBParameterGroups[?contains(DBParameterGroupName, 'postgresql')].DBParameterGroupName"
+
+# MySQL
+aws rds describe-db-parameter-groups \
+  --query "DBParameterGroups[?contains(DBParameterGroupName, 'mysql')].DBParameterGroupName"
+
+# Aurora PostgreSQL
+aws rds describe-db-cluster-parameter-groups \
+  --query "DBClusterParameterGroups[?contains(DBClusterParameterGroupName, 'aurora-postgresql')].DBClusterParameterGroupName"
+
+# Aurora MySQL
+aws rds describe-db-cluster-parameter-groups \
+  --query "DBClusterParameterGroups[?contains(DBClusterParameterGroupName, 'aurora-mysql')].DBClusterParameterGroupName"
+```
+
+---
+
+## 🎉 Summary
+
+You now have:
+- ✅ 13 total parameter groups covering all major RDS versions
+- ✅ Automatic SSL/TLS enforcement for any RDS database version
+- ✅ No more "family mismatch" errors
+- ✅ Easy to maintain and extend
+- ✅ Complete encryption at rest (AWS Config) + in transit (parameter groups)
+
+Your RDS encryption policy is now **future-proof** and works with any database version! 🔒

--- a/deployments/aws/management/policies/encryption-baseline/RDS_ENCRYPTION_GUIDE.md
+++ b/deployments/aws/management/policies/encryption-baseline/RDS_ENCRYPTION_GUIDE.md
@@ -1,0 +1,138 @@
+# RDS Encryption Quick Reference
+
+## ✅ What's Configured
+
+Your AWS environment now enforces RDS encryption for both data at rest and data in transit:
+
+### 1. Data at Rest (Storage Encryption)
+- **AWS Config Rule**: `rds-storage-encrypted`
+- **Monitors**: All RDS instances for storage encryption
+- **Alerts**: Non-compliant instances via SNS
+
+### 2. Data in Transit (SSL/TLS Encryption)
+- **4 Parameter Groups Created**:
+  - `postgresql-ssl-required` - Forces SSL for PostgreSQL
+  - `mysql-ssl-required` - Forces SSL for MySQL
+  - `aurora-postgresql-ssl-required` - Forces SSL for Aurora PostgreSQL
+  - `aurora-mysql-ssl-required` - Forces SSL for Aurora MySQL
+
+## 📋 How to Use
+
+When creating RDS instances, reference these parameter groups:
+
+### PostgreSQL Example
+```hcl
+resource "aws_db_instance" "example" {
+  identifier           = "my-db"
+  engine              = "postgres"
+  engine_version      = "16.1"
+  
+  storage_encrypted   = true                      # ✅ Encryption at rest
+  parameter_group_name = "postgresql-ssl-required" # ✅ Encryption in transit
+}
+```
+
+### MySQL Example
+```hcl
+resource "aws_db_instance" "example" {
+  identifier           = "my-db"
+  engine              = "mysql"
+  engine_version      = "8.0.35"
+  
+  storage_encrypted   = true                   # ✅ Encryption at rest
+  parameter_group_name = "mysql-ssl-required"  # ✅ Encryption in transit
+}
+```
+
+### Aurora PostgreSQL Example
+```hcl
+resource "aws_rds_cluster" "example" {
+  cluster_identifier   = "my-cluster"
+  engine              = "aurora-postgresql"
+  engine_version      = "16.1"
+  
+  storage_encrypted   = true                                        # ✅ Encryption at rest
+  db_cluster_parameter_group_name = "aurora-postgresql-ssl-required" # ✅ Encryption in transit
+}
+```
+
+### Aurora MySQL Example
+```hcl
+resource "aws_rds_cluster" "example" {
+  cluster_identifier   = "my-cluster"
+  engine              = "aurora-mysql"
+  engine_version      = "8.0.mysql_aurora.3.05.2"
+  
+  storage_encrypted   = true                                   # ✅ Encryption at rest
+  db_cluster_parameter_group_name = "aurora-mysql-ssl-required" # ✅ Encryption in transit
+}
+```
+
+## ✔️ Verification
+
+### Check Parameter Value (PostgreSQL)
+```bash
+psql -h your-endpoint.rds.amazonaws.com -U username -d database \
+  -c "SHOW rds.force_ssl;"
+```
+Expected output: `rds.force_ssl = on`
+
+### Check Parameter Value (MySQL)
+```bash
+mysql -h your-endpoint.rds.amazonaws.com -u username -p \
+  -e "SHOW VARIABLES LIKE 'require_secure_transport';"
+```
+Expected output: `require_secure_transport = ON`
+
+### Check Encryption at Rest
+```bash
+aws rds describe-db-instances \
+  --db-instance-identifier my-db \
+  --query 'DBInstances[0].StorageEncrypted'
+```
+Expected output: `true`
+
+## 📊 Monitoring
+
+View compliance in AWS Config:
+```bash
+aws configservice describe-compliance-by-config-rule \
+  --config-rule-names rds-storage-encrypted
+```
+
+Or visit: https://console.aws.amazon.com/config/home?region=eu-north-1#/dashboard
+
+## 🔐 Security Checklist
+
+- [x] RDS storage encryption enabled via Config rule
+- [x] SSL/TLS parameter groups created for all RDS engine types
+- [x] Compliance monitoring active
+- [x] SNS alerts configured for violations
+- [ ] Apply parameter groups to existing RDS instances
+- [ ] Verify SSL enforcement on all databases
+- [ ] Document database connection strings require SSL
+
+## 📝 Next Steps
+
+1. **Update existing RDS instances** to use the SSL-enforcing parameter groups
+2. **Verify SSL is active** using the verification commands above
+3. **Update application connection strings** to use SSL (if not already)
+4. **Check AWS Config dashboard** for any non-compliant resources
+
+## ⚠️ Important Notes
+
+- **Parameter group changes** require instance reboot
+- **Aurora changes** typically don't require reboot but may take a few minutes
+- **Version compatibility**: Update the `family` in main.tf if using different engine versions
+- **Existing instances**: Apply parameter groups manually or via Terraform
+
+## 🛠️ Troubleshooting
+
+### Issue: "Cannot use parameter group family X with engine version Y"
+**Solution**: Update the `family` parameter in [main.tf](main.tf) lines 412, 425, 438, 451 to match your engine version.
+
+### Issue: SSL still not enforced after applying parameter group
+**Solution**: 
+1. Verify parameter group is attached: `aws rds describe-db-instances --db-instance-identifier my-db`
+2. Reboot the instance: `aws rds reboot-db-instance --db-instance-identifier my-db`
+3. Check parameter value using verification commands above

--- a/deployments/aws/management/policies/encryption-baseline/outputs.tf
+++ b/deployments/aws/management/policies/encryption-baseline/outputs.tf
@@ -24,3 +24,63 @@ output "compliance_dashboard_url" {
   description = "URL to view compliance dashboard"
   value       = "https://console.aws.amazon.com/config/home?region=${var.aws_region}#/dashboard"
 }
+
+# RDS Parameter Groups for SSL Enforcement
+output "rds_parameter_groups" {
+  description = "RDS parameter groups that enforce SSL/TLS connections (all versions)"
+  value = {
+    postgresql = {
+      for family in local.postgresql_families :
+      family => {
+        name   = aws_db_parameter_group.postgresql_ssl_required[family].name
+        arn    = aws_db_parameter_group.postgresql_ssl_required[family].arn
+        family = aws_db_parameter_group.postgresql_ssl_required[family].family
+      }
+    }
+    mysql = {
+      for family in local.mysql_families :
+      family => {
+        name   = aws_db_parameter_group.mysql_ssl_required[family].name
+        arn    = aws_db_parameter_group.mysql_ssl_required[family].arn
+        family = aws_db_parameter_group.mysql_ssl_required[family].family
+      }
+    }
+    aurora_postgresql = {
+      for family in local.aurora_pg_families :
+      family => {
+        name   = aws_rds_cluster_parameter_group.aurora_postgresql_ssl_required[family].name
+        arn    = aws_rds_cluster_parameter_group.aurora_postgresql_ssl_required[family].arn
+        family = aws_rds_cluster_parameter_group.aurora_postgresql_ssl_required[family].family
+      }
+    }
+    aurora_mysql = {
+      for family in local.aurora_my_families :
+      family => {
+        name   = aws_rds_cluster_parameter_group.aurora_mysql_ssl_required[family].name
+        arn    = aws_rds_cluster_parameter_group.aurora_mysql_ssl_required[family].arn
+        family = aws_rds_cluster_parameter_group.aurora_mysql_ssl_required[family].family
+      }
+    }
+  }
+}
+
+output "rds_ssl_enforcement_instructions" {
+  description = "Instructions for using SSL-enforcing parameter groups"
+  value = <<-EOT
+    To enforce SSL/TLS for RDS instances:
+    
+    Available PostgreSQL parameter groups (by version):
+    ${join("\n    ", [for f in local.postgresql_families : "- ${aws_db_parameter_group.postgresql_ssl_required[f].name}"])}
+    
+    Available MySQL parameter groups (by version):
+    ${join("\n    ", [for f in local.mysql_families : "- ${aws_db_parameter_group.mysql_ssl_required[f].name}"])}
+    
+    Available Aurora PostgreSQL parameter groups (by version):
+    ${join("\n    ", [for f in local.aurora_pg_families : "- ${aws_rds_cluster_parameter_group.aurora_postgresql_ssl_required[f].name}"])}
+    
+    Available Aurora MySQL parameter groups (by version):
+    ${join("\n    ", [for f in local.aurora_my_families : "- ${aws_rds_cluster_parameter_group.aurora_mysql_ssl_required[f].name}"])}
+    
+    Select the parameter group that matches your RDS instance version.
+  EOT
+}


### PR DESCRIPTION
Introduce parameter groups for enforcing SSL/TLS connections on RDS instances across PostgreSQL, MySQL, and Aurora databases. Update documentation to include usage instructions and details on available parameter groups for each database engine version. Ensure compliance with encryption standards.