### PR TITLE
Add PSScriptAnalyzer workflow configuration

### DIFF
--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -29,14 +29,14 @@ jobs:
     name: PSScriptAnalyzer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Run PSScriptAnalyzer
         uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f
         with:
           # Check https://github.com/microsoft/action-psscriptanalyzer for more info about the options.
           # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.
-          path: .\
+          path: .
           recurse: true
           # Include your own basic security rules. Removing this option will run all the rules
           includeRule: '"PSAvoidGlobalAliases", "PSAvoidUsingConvertToSecureStringWithPlainText"'
@@ -44,6 +44,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@b7d54e27d4f1c9c2e5f3f3d9f1e6c4c0f5f8b4e2 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -11,7 +11,7 @@ name: PSScriptAnalyzer
 
 on:
   push:
-    branches: [ "main", "branch-pattern-main" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   schedule:

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Run PSScriptAnalyzer
-        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f
+        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f # v1
         with:
           # Check https://github.com/microsoft/action-psscriptanalyzer for more info about the options.
           # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -1,0 +1,49 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# https://github.com/microsoft/action-psscriptanalyzer
+# For more information on PSScriptAnalyzer in general, see
+# https://github.com/PowerShell/PSScriptAnalyzer
+
+name: PSScriptAnalyzer
+
+on:
+  push:
+    branches: [ "main", "branch-pattern-main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '26 5 * * 4'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run PSScriptAnalyzer
+        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f
+        with:
+          # Check https://github.com/microsoft/action-psscriptanalyzer for more info about the options.
+          # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.
+          path: .\
+          recurse: true
+          # Include your own basic security rules. Removing this option will run all the rules
+          includeRule: '"PSAvoidGlobalAliases", "PSAvoidUsingConvertToSecureStringWithPlainText"'
+          output: results.sarif
+
+      # Upload the SARIF file generated in the previous step
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  analyze:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results


### PR DESCRIPTION
This workflow configures PSScriptAnalyzer to run on pushes and pull requests to the main branch, as well as on a schedule. It includes steps for checking out the code, running the analyzer, and uploading SARIF results.